### PR TITLE
Add FastAPI server for online use

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,13 @@ python backtest.py --csv path/to/data.csv --from-tz CST
 The CSV file should include the columns `Timestamp`, `Open`, `High`, `Low`, `Close`, and `Volume`. Timestamps are converted from the provided timezone (default `US/Central`) to Indian Standard Time before analysis.
 
 The script outputs the number of trades, wins, losses, a win/loss ratio, and the most profitable days.
+
+## Running as a Web Service
+
+A small FastAPI application is included to expose the backtester over HTTP. Run it with:
+
+```
+uvicorn server:app --reload
+```
+
+Send a POST request to `/backtest` with a CSV file in the form field `file`. The endpoint returns a JSON summary that can be consumed by a front end.

--- a/backtest.py
+++ b/backtest.py
@@ -139,8 +139,12 @@ class Backtester:
         }
 
 
-def load_data(path, from_tz='US/Central', to_tz='Asia/Kolkata'):
-    df = pd.read_csv(path)
+def load_data(data, from_tz='US/Central', to_tz='Asia/Kolkata'):
+    """Load candle data from a CSV path or a DataFrame and convert timezones."""
+    if isinstance(data, pd.DataFrame):
+        df = data.copy()
+    else:
+        df = pd.read_csv(data)
     if 'Timestamp' not in df.columns:
         raise ValueError('CSV must contain Timestamp column')
     df['Timestamp'] = pd.to_datetime(df['Timestamp'])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
 pandas
 pytz
+fastapi
+uvicorn[standard]
+python-multipart

--- a/server.py
+++ b/server.py
@@ -1,0 +1,18 @@
+from fastapi import FastAPI, UploadFile, File, HTTPException
+import pandas as pd
+from backtest import load_data, Backtester
+
+app = FastAPI()
+
+@app.post('/backtest')
+async def run_backtest(file: UploadFile = File(...), from_tz: str = 'US/Central'):
+    try:
+        contents = await file.read()
+        df = pd.read_csv(pd.compat.StringIO(contents.decode()))
+        df = load_data(df, from_tz=from_tz)
+        bt = Backtester(df)
+        bt.run()
+        summary = bt.summary()
+        return summary
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))


### PR DESCRIPTION
## Summary
- add FastAPI web server to run backtests from an uploaded CSV
- make `load_data` accept a DataFrame or CSV path
- document running the server in the README
- update dependencies

## Testing
- `python -m py_compile backtest.py server.py`


------
https://chatgpt.com/codex/tasks/task_e_683f57c5e05c83248421aa19fb487486